### PR TITLE
Add JSON endpoints to expose percentages

### DIFF
--- a/src/main/java/io/micronaut/starter/analytics/postgres/AnalyticsController.java
+++ b/src/main/java/io/micronaut/starter/analytics/postgres/AnalyticsController.java
@@ -102,7 +102,7 @@ public class AnalyticsController {
         Application saved = applicationRepository.save(application);
         List<Feature> features = generated.getSelectedFeatures().stream()
                 .map(f -> new Feature(saved, f.getName()))
-                .collect(Collectors.toList());
+                .toList();
 
         featureRepository.saveAll(features);
         return HttpStatus.ACCEPTED;

--- a/src/main/java/io/micronaut/starter/analytics/postgres/FeatureRepository.java
+++ b/src/main/java/io/micronaut/starter/analytics/postgres/FeatureRepository.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @JdbcRepository(dialect = Dialect.POSTGRES)
-abstract class FeatureRepository implements CrudRepository<Feature, Long> {
+public abstract class FeatureRepository implements CrudRepository<Feature, Long> {
 
     private static final String FIELD_APPLICATION_TYPE = "type";
     private static final String FIELD_BUILD_TOOL = "build_tool";

--- a/src/main/java/io/micronaut/starter/analytics/postgres/PercentageController.java
+++ b/src/main/java/io/micronaut/starter/analytics/postgres/PercentageController.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.analytics.postgres;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.micronaut.security.annotation.Secured;
+import io.micronaut.security.rules.SecurityRule;
+
+@Controller(AnalyticsController.PATH + "/percentages")
+@Secured(SecurityRule.IS_ANONYMOUS)
+@ExecuteOn(TaskExecutors.BLOCKING)
+class PercentageController {
+
+    private final FeatureRepository featureRepository;
+
+    PercentageController(FeatureRepository featureRepository) {
+        this.featureRepository = featureRepository;
+    }
+
+    @Get("/types")
+    PercentageResponse applicationType() {
+        return new PercentageResponse(featureRepository.applicationTypePercentages());
+    }
+
+    @Get("/buildTools")
+    PercentageResponse buildTool() {
+        return new PercentageResponse(featureRepository.buildToolPercentages());
+    }
+
+    @Get("/jdks")
+    PercentageResponse jdks() {
+        return new PercentageResponse(featureRepository.jdkPercentages());
+    }
+
+    @Get("/languages")
+    PercentageResponse languages() {
+        return new PercentageResponse(featureRepository.languagePercentages());
+    }
+
+    @Get("/testFrameworks")
+    PercentageResponse testFrameworks() {
+        return new PercentageResponse(featureRepository.testFrameworkPercentages());
+    }
+}

--- a/src/main/java/io/micronaut/starter/analytics/postgres/PercentageDTO.java
+++ b/src/main/java/io/micronaut/starter/analytics/postgres/PercentageDTO.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.analytics.postgres;
+
+public record PercentageDTO(String name, double percentage) {
+}

--- a/src/main/java/io/micronaut/starter/analytics/postgres/PercentageResponse.java
+++ b/src/main/java/io/micronaut/starter/analytics/postgres/PercentageResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.starter.analytics.postgres;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+
+@Serdeable
+public record PercentageResponse(@JsonIgnore List<PercentageDTO> percentages) {
+
+    /**
+     * Collector that groups by name and sums the percentages.
+     */
+    private static final Collector<PercentageDTO, ?, Map<String, Double>> PERCENTAGE_DTO_MAP_COLLECTOR =
+            Collectors.groupingBy(PercentageDTO::name, Collectors.summingDouble(PercentageDTO::percentage));
+
+    public Optional<Double> percentageFor(String name) {
+        return percentages.stream()
+                .filter(p -> p.name().equals(name))
+                .map(PercentageDTO::percentage)
+                .findFirst();
+    }
+
+    @JsonAnyGetter
+    public Map<String, Map<String, Double>> getPercentage() {
+        return Map.of("percentages", percentages.stream().collect(PERCENTAGE_DTO_MAP_COLLECTOR));
+    }
+}

--- a/src/main/resources/application-gcp.properties
+++ b/src/main/resources/application-gcp.properties
@@ -1,4 +1,3 @@
-datasources.default.db-type=postgres
 datasources.default.dialect=POSTGRES
 micronaut.application.name=starter-analytics
 datasources.default.driver-class-name=org.postgresql.Driver

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 flyway.datasources.default.locations=classpath:databasemigrations
 flyway.datasources.default.enabled=true
 micronaut.security.token.bearer.enabled=false
+datasources.default.db-type=postgres

--- a/src/test/java/io/micronaut/starter/analytics/postgres/AbstractDataTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/AbstractDataTest.java
@@ -16,7 +16,6 @@ abstract class AbstractDataTest {
 
     @AfterEach
     void cleanup() {
-        System.out.println("Cleaning up");
         featureRepository.deleteAll();
         applicationRepository.deleteAll();
     }

--- a/src/test/java/io/micronaut/starter/analytics/postgres/AbstractDataTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/AbstractDataTest.java
@@ -1,0 +1,23 @@
+package io.micronaut.starter.analytics.postgres;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+
+@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
+abstract class AbstractDataTest {
+
+    @Inject
+    ApplicationRepository applicationRepository;
+
+    @Inject
+    FeatureRepository featureRepository;
+
+    @AfterEach
+    void cleanup() {
+        System.out.println("Cleaning up");
+        featureRepository.deleteAll();
+        applicationRepository.deleteAll();
+    }
+}

--- a/src/test/java/io/micronaut/starter/analytics/postgres/AnalyticsControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/AnalyticsControllerTest.java
@@ -29,20 +29,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Property(name = "api.key", value = API_KEY)
-@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
-class AnalyticsControllerTest {
+class AnalyticsControllerTest extends AbstractDataTest {
 
     public static final String API_KEY = "xxx";
 
     @Inject
     @Client("/")
     HttpClient httpClient;
-
-    @Inject
-    ApplicationRepository applicationRepository;
-
-    @Inject
-    FeatureRepository featureRepository;
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -84,9 +77,6 @@ class AnalyticsControllerTest {
         assertFalse(totalDTOList.isEmpty());
         assertEquals("junit", totalDTOList.get(0).getName());
         assertEquals(1, totalDTOList.get(0).getTotal());
-
-        applicationRepository.deleteAll();
-        featureRepository.deleteAll();
     }
 
     private static List<TotalDTO> totalDtoRequest(BlockingHttpClient client, String path) {

--- a/src/test/java/io/micronaut/starter/analytics/postgres/AnalyticsControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/AnalyticsControllerTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Property(name = "api.key", value = API_KEY)
-@MicronautTest(environments = {Environment.GOOGLE_COMPUTE})
+@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
 class AnalyticsControllerTest {
 
     public static final String API_KEY = "xxx";
@@ -40,6 +40,9 @@ class AnalyticsControllerTest {
 
     @Inject
     ApplicationRepository applicationRepository;
+
+    @Inject
+    FeatureRepository featureRepository;
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -83,6 +86,7 @@ class AnalyticsControllerTest {
         assertEquals(1, totalDTOList.get(0).getTotal());
 
         applicationRepository.deleteAll();
+        featureRepository.deleteAll();
     }
 
     private static List<TotalDTO> totalDtoRequest(BlockingHttpClient client, String path) {

--- a/src/test/java/io/micronaut/starter/analytics/postgres/ExcelGeneratorTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/ExcelGeneratorTest.java
@@ -16,6 +16,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 import java.util.HashMap;
 import java.util.List;
@@ -27,16 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Property(name = "micronaut.starter.analytics.page-size", value = "5")
 @Property(name = "spec.name", value = "ExcelGeneratorSpec")
-@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
-class ExcelGeneratorTest {
+@DisabledInNativeImage
+class ExcelGeneratorTest extends AbstractDataTest {
     @Inject
     ExcelGenerator excelGenerator;
-
-    @Inject
-    ApplicationRepository applicationRepository;
-
-    @Inject
-    FeatureRepository featureRepository;
 
     @Test
     void generateSpreadsheetWithOneApplication() {
@@ -78,9 +73,6 @@ class ExcelGeneratorTest {
         assertEquals(8, row.getCell(JDK_VERSION.ordinal()).getNumericCellValue());
         assertEquals(row.getCell(MICRONAUT_VERSION.ordinal()).getStringCellValue(), "4.0.0");
         assertEquals(row.getCell(DATE_CREATED.ordinal()).getNumericCellValue(), DateUtil.getExcelDate(app.getDateCreated(), false));
-
-        featureRepository.deleteAll();
-        applicationRepository.deleteAll();
     }
 
     @Test
@@ -195,9 +187,6 @@ class ExcelGeneratorTest {
         row = sheet.getRow(12);
         assertEquals(row.getCell(ID.ordinal()).getNumericCellValue(), apps.get(11).getId().doubleValue());
         assertEquals(row.getCell(FEATURES.ordinal()).getStringCellValue(), "twelve");
-
-        featureRepository.deleteAll();
-        applicationRepository.deleteAll();
     }
 
     @Test
@@ -221,6 +210,5 @@ class ExcelGeneratorTest {
         assertEquals(row.getCell(JDK_VERSION.ordinal()).getStringCellValue(), JDK_VERSION.title);
         assertEquals(row.getCell(MICRONAUT_VERSION.ordinal()).getStringCellValue(), MICRONAUT_VERSION.title);
         assertEquals(row.getCell(DATE_CREATED.ordinal()).getStringCellValue(), DATE_CREATED.title);
-
     }
 }

--- a/src/test/java/io/micronaut/starter/analytics/postgres/ExcelGeneratorTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/ExcelGeneratorTest.java
@@ -78,6 +78,7 @@ class ExcelGeneratorTest {
         assertEquals(8, row.getCell(JDK_VERSION.ordinal()).getNumericCellValue());
         assertEquals(row.getCell(MICRONAUT_VERSION.ordinal()).getStringCellValue(), "4.0.0");
         assertEquals(row.getCell(DATE_CREATED.ordinal()).getNumericCellValue(), DateUtil.getExcelDate(app.getDateCreated(), false));
+
         featureRepository.deleteAll();
         applicationRepository.deleteAll();
     }

--- a/src/test/java/io/micronaut/starter/analytics/postgres/GenerateExcelTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/GenerateExcelTest.java
@@ -23,6 +23,7 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -36,20 +37,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Property(name = "spec.name", value = "GenerateExcelSpec")
 @Property(name = "api.key", value = "wonderful")
-@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
-class GenerateExcelTest {
+@DisabledInNativeImage
+class GenerateExcelTest extends AbstractDataTest {
 
     @Inject
     AnalyticsClient client;
-    @Inject
-    ApplicationRepository repository;
-
-    @Inject FeatureRepository featureRepository;
 
     @Test
     void verifyGeneratedExcel() throws ExecutionException, InterruptedException, IOException {
         //given: "there is one application stored in the repository"
-        Application app = repository.save(new Application(ApplicationType.DEFAULT, Language.JAVA, BuildTool.GRADLE, TestFramework.SPOCK, JdkVersion.JDK_8, "4.0.1"));
+        Application app = applicationRepository.save(new Application(ApplicationType.DEFAULT, Language.JAVA, BuildTool.GRADLE, TestFramework.SPOCK, JdkVersion.JDK_8, "4.0.1"));
         featureRepository.saveAll(Arrays.asList(new Feature(app, "micronaut-http-validation"), new Feature(app, "http-client")));
 
         //when: "the spreadsheet is generated"
@@ -87,9 +84,6 @@ class GenerateExcelTest {
         assertEquals(row.getCell(JDK_VERSION.ordinal()).getNumericCellValue(), 8);
         assertEquals(row.getCell(MICRONAUT_VERSION.ordinal()).getStringCellValue(), "4.0.1");
         assertEquals(row.getCell(DATE_CREATED.ordinal()).getNumericCellValue(), DateUtil.getExcelDate(app.getDateCreated(), false));
-
-        featureRepository.deleteAll();
-        repository.deleteAll();
     }
 
     @Requires(property = "spec.name", value = "GenerateExcelSpec")

--- a/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
@@ -25,20 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Property(name = "api.key", value = API_KEY)
-@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
-class PercentageControllerTest {
+class PercentageControllerTest extends AbstractDataTest {
 
     private static final String API_KEY = "xxx";
 
     @Inject
     @Client("/")
     HttpClient httpClient;
-
-    @Inject
-    FeatureRepository featureRepository;
-
-    @Inject
-    ApplicationRepository applicationRepository;
 
     @Inject
     JsonMapper jsonMapper;
@@ -76,9 +69,6 @@ class PercentageControllerTest {
         assertPercentage(client, "/analytics/percentages/buildTools", Map.of("gradle_kotlin", 0.5d, "gradle", 0.25d, "maven", 0.25d));
         assertPercentage(client, "/analytics/percentages/languages", Map.of("java", 0.5d, "groovy", 0.25d, "kotlin", 0.25d));
         assertPercentage(client, "/analytics/percentages/testFrameworks", Map.of("spock", 0.5d, "junit", 0.25d, "kotest", 0.25d));
-
-        featureRepository.deleteAll();
-        applicationRepository.deleteAll();
     }
 
     void assertPercentage(BlockingHttpClient client, String path, Map<String, Double> expected) {

--- a/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
@@ -42,6 +42,7 @@ class PercentageControllerTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+            "/analytics/percentages/types",
             "/analytics/percentages/jdks",
             "/analytics/percentages/buildTools",
             "/analytics/percentages/languages",

--- a/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Property(name = "api.key", value = API_KEY)
-@MicronautTest(environments = {Environment.GOOGLE_COMPUTE})
+@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
 class PercentageControllerTest {
 
     private static final String API_KEY = "xxx";
@@ -33,6 +33,9 @@ class PercentageControllerTest {
     @Inject
     @Client("/")
     HttpClient httpClient;
+
+    @Inject
+    FeatureRepository featureRepository;
 
     @Inject
     ApplicationRepository applicationRepository;
@@ -73,6 +76,9 @@ class PercentageControllerTest {
         assertPercentage(client, "/analytics/percentages/buildTools", Map.of("gradle_kotlin", 0.5d, "gradle", 0.25d, "maven", 0.25d));
         assertPercentage(client, "/analytics/percentages/languages", Map.of("java", 0.5d, "groovy", 0.25d, "kotlin", 0.25d));
         assertPercentage(client, "/analytics/percentages/testFrameworks", Map.of("spock", 0.5d, "junit", 0.25d, "kotest", 0.25d));
+
+        featureRepository.deleteAll();
+        applicationRepository.deleteAll();
     }
 
     void assertPercentage(BlockingHttpClient client, String path, Map<String, Double> expected) {

--- a/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/PercentageControllerTest.java
@@ -1,0 +1,103 @@
+package io.micronaut.starter.analytics.postgres;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.context.env.Environment;
+import io.micronaut.core.type.Argument;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MutableHttpRequest;
+import io.micronaut.http.client.BlockingHttpClient;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static io.micronaut.starter.analytics.postgres.AnalyticsControllerTest.API_KEY;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Property(name = "api.key", value = API_KEY)
+@MicronautTest(environments = {Environment.GOOGLE_COMPUTE})
+class PercentageControllerTest {
+
+    private static final String API_KEY = "xxx";
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient;
+
+    @Inject
+    ApplicationRepository applicationRepository;
+
+    @Inject
+    JsonMapper jsonMapper;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/analytics/percentages/jdks",
+            "/analytics/percentages/buildTools",
+            "/analytics/percentages/languages",
+            "/analytics/percentages/testFrameworks"
+    })
+    void apiDoesNotRequireAuthentication(String path) {
+        BlockingHttpClient client = httpClient.toBlocking();
+        HttpResponse<String> response = assertDoesNotThrow(() -> client.exchange(HttpRequest.GET(path), Argument.of(String.class)));
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertDoesNotThrow(() -> response.getBody().map(this::parse).orElseThrow());
+    }
+
+    @Test
+    void checkAccuracy() {
+        BlockingHttpClient client = httpClient.toBlocking();
+        String setupJson = """
+                {"type":"DEFAULT","language":"java","testFramework":"junit","buildTool":"gradle","jdkVersion":"JDK_17"}
+                {"type":"DEFAULT","language":"java","testFramework":"spock","buildTool":"gradle_kotlin","jdkVersion":"JDK_21"}
+                {"type":"FUNCTION","language":"groovy","testFramework":"spock","buildTool":"gradle_kotlin","jdkVersion":"JDK_17"}
+                {"type":"FUNCTION","language":"kotlin","testFramework":"kotest","buildTool":"maven","jdkVersion":"JDK_17"}
+                """;
+        setupJson.lines().forEach(line -> {
+            assertDoesNotThrow(() -> client.exchange(decorateRequest(HttpRequest.POST("/analytics/report", line))));
+        });
+
+        assertPercentage(client, "/analytics/percentages/types", Map.of("FUNCTION", 0.5d, "DEFAULT", 0.5d));
+        assertPercentage(client, "/analytics/percentages/jdks", Map.of("JDK_21", 0.25d, "JDK_17", 0.75d));
+        assertPercentage(client, "/analytics/percentages/buildTools", Map.of("gradle_kotlin", 0.5d, "gradle", 0.25d, "maven", 0.25d));
+        assertPercentage(client, "/analytics/percentages/languages", Map.of("java", 0.5d, "groovy", 0.25d, "kotlin", 0.25d));
+        assertPercentage(client, "/analytics/percentages/testFrameworks", Map.of("spock", 0.5d, "junit", 0.25d, "kotest", 0.25d));
+    }
+
+    void assertPercentage(BlockingHttpClient client, String path, Map<String, Double> expected) {
+        HttpResponse<String> response = assertDoesNotThrow(() -> client.exchange(HttpRequest.GET(path), Argument.of(String.class)));
+        PercentageResponse percentages = response.getBody().map(this::parse).orElseThrow();
+        assertEquals(expected.size(), percentages.percentages().size(), () -> "Expected " + expected + " from " + path + " but got " + percentages.percentages());
+        expected.forEach((name, percentage) ->
+                // assert equals with a 0.01 delta (as doubles are not exact)
+                assertEquals(percentage, percentages.percentageFor(name).orElseThrow(), 0.01d, () -> "Expected " + percentage + " from " + path + " for " + name + " but got " + percentages.percentages())
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private PercentageResponse parse(String body) {
+        try {
+            Map<String, Map<String, Double>> map = jsonMapper.readValue(body, Map.class);
+            Map<String, Double> contents = map.get("percentages");
+            return new PercentageResponse(
+                    contents.entrySet().stream().map(e -> new PercentageDTO(e.getKey(), e.getValue())).toList()
+            );
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static MutableHttpRequest<?> decorateRequest(MutableHttpRequest<?> request) {
+        return request.header("X-API-KEY", API_KEY);
+    }
+}

--- a/src/test/java/io/micronaut/starter/analytics/postgres/StoreGeneratedProjectStatsTest.java
+++ b/src/test/java/io/micronaut/starter/analytics/postgres/StoreGeneratedProjectStatsTest.java
@@ -36,14 +36,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Property(name = "spec.name", value = "StoreGeneratedProjectStatsSpec")
 @Property(name = "api.key", value = "wonderful")
-@MicronautTest(transactional = false, environments = {Environment.GOOGLE_COMPUTE})
-class StoreGeneratedProjectStatsTest {
+class StoreGeneratedProjectStatsTest extends AbstractDataTest {
 
     @Inject UnauthorizedAnalyticsClient unauthorizedClient;
     @Inject WrongApiKeyClient wrongApiKeyClient;
     @Inject AnalyticsClient client;
-    @Inject ApplicationRepository repository;
-    @Inject FeatureRepository featureRepository;
 
     @Test
     void testSaveGenerationDataWithoutApiKey() throws ExecutionException, InterruptedException {
@@ -94,7 +91,7 @@ class StoreGeneratedProjectStatsTest {
         HttpStatus status = client.applicationGenerated(generated).get();
         assertEquals(HttpStatus.ACCEPTED, status);
 
-        Application application = repository.list(Pageable.UNPAGED).getContent().get(0);
+        Application application = applicationRepository.list(Pageable.UNPAGED).getContent().get(0);
 
         assertEquals(generated.getType(), application.getType());
         assertEquals(application.getLanguage(), generated.getLanguage());
@@ -118,9 +115,6 @@ class StoreGeneratedProjectStatsTest {
         assertTrue(CollectionUtils.isNotEmpty(featureRepository.topBuildTools()));
         assertTrue(CollectionUtils.isNotEmpty(featureRepository.topJdkVersion()));
         assertTrue(CollectionUtils.isNotEmpty(featureRepository.topTestFrameworks()));
-
-        featureRepository.deleteAll();
-        repository.deleteAll();
     }
 
     @Requires(property = "spec.name", value = "StoreGeneratedProjectStatsSpec")


### PR DESCRIPTION
Closes #7 

This adds unauthenticated endpoints that expose percentages for the following:

Path  | example
--- | ---
`/analytics/percentages/types` | `{"percentages":{"FUNCTION":0.5,"DEFAULT":0.5}}`
`/analytics/percentages/jdks` | `{"percentages":{"JDK_21":0.25,"JDK_17":0.75}}`
`/analytics/percentages/buildTools` | `{"percentages":{"gradle_kotlin":0.5,"gradle":0.25,"maven":0.25}}`
`/analytics/percentages/languages` | `{"percentages":{"java":0.5,"groovy":0.25,"kotlin":0.25}}`
`/analytics/percentages/testFrameworks` | `{"percentages":{"junit":0.25,"spock":0.5,"kotest":0.25}}`
